### PR TITLE
Security fix,  must be an not empty string

### DIFF
--- a/web/smart_lock_log_api.php
+++ b/web/smart_lock_log_api.php
@@ -5,15 +5,15 @@ include 'database_config.php';
 //key must be same as in bash script
 $result = $conn->query("SELECT psk FROM preshared_key WHERE name='api_psk'");
 
-if ($result->num_rows > 0) 
+if ($result->num_rows > 0)
 {
     // output data of each row
-    while($row = $result->fetch_assoc()) 
+    while($row = $result->fetch_assoc())
     {
         $key = $row["psk"];
     }
-} 
-else 
+}
+else
 {
     echo "0 results";
 }
@@ -26,24 +26,26 @@ $totalSpentTime = '';
 
 $calculated_validator = hash_hmac ('sha1', $date, $key);
 
-if(strcmp($calculated_validator,$validator) === 0)
+if(!is_string($validator) || strlen($validator) < 1)
 {
-    if ($conn->connect_errno) 
+    echo "We don't take kindly of your kind around here! <br>";
+}
+elseif(strcmp($calculated_validator,$validator) === 0)
+{
+    if ($conn->connect_errno)
     {
       exit('Can\'t connect : '. $conn->connect_error);
     }
 
     $user = $_GET["user"];
-    if ($conn->query("INSERT INTO smart_lock_log (user) VALUES ('$user')") === TRUE) 
+    if ($conn->query("INSERT INTO smart_lock_log (user) VALUES ('$user')") === TRUE)
     {
         echo "New record created successfully<br>";
-        
-    } 
-    else 
+    }
+    else
     {
         echo "Error: INSERT INTO smart_lock_log (user) VALUES ('$user') <br>" . $conn->error."<br>";
     }
-
 }
 else echo "Validator is wrong";
 

--- a/web/temp_api.php
+++ b/web/temp_api.php
@@ -27,23 +27,27 @@ $totalSpentTime = '';
 
 $calculated_validator = hash_hmac ('sha1', $date, $key);
 
-if(strcmp($calculated_validator,$validator) === 0)
+if(!is_string($validator) || strlen($validator) < 1)
 {
-    if ($conn->connect_errno) 
+    echo "We don't take kindly of your kind here! <br>";
+}
+elseif(strcmp($calculated_validator,$validator) === 0)
+{
+    if ($conn->connect_errno)
     {
       exit('Can\'t connect : '. $conn->connect_error);
     }
 
     $temp = $_GET["temp"];
-    
+
     updateCarbon("hacklab.temp", $temp);
-    
-    if ($conn->query("UPDATE temp SET temp='$temp', ts=current_timestamp WHERE id =1") === TRUE) 
+
+    if ($conn->query("UPDATE temp SET temp='$temp', ts=current_timestamp WHERE id =1") === TRUE)
     {
         echo "New record created successfully<br>";
-        
-    } 
-    else 
+
+    }
+    else
     {
         echo "UPDATE temp SET temp='$temp' WHERE id = 1 <br>" . $conn->error."<br>";
     }


### PR DESCRIPTION
Added if(!is_string($validator) || strlen($validator) < 1) to api-s,
removed some trailing spaces.